### PR TITLE
Remove deprecation alert in build errors

### DIFF
--- a/LBTAComponents/Classes/NSMutableAttributedString+Helper.swift
+++ b/LBTAComponents/Classes/NSMutableAttributedString+Helper.swift
@@ -28,7 +28,7 @@ extension NSMutableAttributedString {
     }
     
     func setParagraphStyle(paragraphStyle: NSParagraphStyle) {
-        let range = NSMakeRange(0, string.characters.count)
+        let range = NSMakeRange(0, string.count)
         addAttribute(NSAttributedStringKey.paragraphStyle, value: paragraphStyle, range: range)
     }
 }


### PR DESCRIPTION
`String.characters` will soon be deprecated, updated the code to get ride of the annoying yellow warning in build errors.